### PR TITLE
Correcting_pipe_cardinality_name

### DIFF
--- a/nullius/prototypes/entity/pipe_graphics.lua
+++ b/nullius/prototypes/entity/pipe_graphics.lua
@@ -385,7 +385,7 @@ function hydropipepictures()
       shift = { 0.06, -0.6 },
     },
     west = {
-      filename = "__angelsrefininggraphics__/graphics/entity/hydro-plant/pipe-east1.png",
+      filename = "__angelsrefininggraphics__/graphics/entity/hydro-plant/pipe-west1.png",
       priority = "extra-high",
       width = 48,
       height = 48,
@@ -418,7 +418,7 @@ function hydropipepictures2()
       shift = { 0.06, -0.6 },
     },
     west = {
-      filename = "__angelsrefininggraphics__/graphics/entity/hydro-plant/pipe-east2.png",
+      filename = "__angelsrefininggraphics__/graphics/entity/hydro-plant/pipe-west2.png",
       priority = "extra-high",
       width = 48,
       height = 48,


### PR DESCRIPTION
Names of the "east-pipe" where changed to reflect that they were actually the west-pipe. 
This was making code modification confusing, as you would be modifying the west pipe config:

```
west = {
      filename = "__angelsrefininggraphics__/graphics/entity/hydro-plant/pipe-east1.png",
```

Now:

```
west = {
      filename = "__angelsrefininggraphics__/graphics/entity/hydro-plant/pipe-west1.png",
```
