### PR TITLE
Fix editor deletion of entities like turbines

### DIFF
--- a/nullius/scripts/build.lua
+++ b/nullius/scripts/build.lua
@@ -80,12 +80,13 @@ function entity_died(event)
   entity_removed(event.entity, true)
 end
 function entity_destroyed(event)
-  if (script_kill or (event.unit_number == nil)) then return end
-  if (destroyed_stirling_engine(event.unit_number)) then return end
-  if (destroyed_wind_turbine(event.unit_number)) then return end
-  if (remove_beacon(event.unit_number)) then return end
-  if (remove_turbine(event.unit_number)) then return end
-  if (remove_transmitter(event.unit_number)) then return end
+  if (script_kill or (event.type ~= defines.target_type.entity)) then return end
+  local unit_number = event.useful_id
+  if (destroyed_stirling_engine(unit_number)) then return end
+  if (destroyed_wind_turbine(unit_number)) then return end
+  if (remove_beacon(unit_number)) then return end
+  if (remove_turbine(unit_number)) then return end
+  if (remove_transmitter(unit_number)) then return end
 end
 
 


### PR DESCRIPTION
The Lua API appears to have changed from Factorio 1.1. The `on_object_destroyed` event does not have a `unit_number` field. Instead, it has a `useful_id` field that, for entities, is the unit number.

This fixes deleting turbines from the map editor.