### PR TITLE
Fix the version for Angel's graphics mods to 1.0.0 for compatibility

### DIFF
--- a/nullius/info.json
+++ b/nullius/info.json
@@ -9,9 +9,9 @@
   "dependencies": [
     "base >= 2.0.72",
     "alien-biomes >= 0.7.4",
-	"angelsrefininggraphics >= 1.0.0",
-    "angelssmeltinggraphics >= 1.0.0",
-    "angelspetrochemgraphics >= 1.0.0",
+	"angelsrefininggraphics = 1.0.0",
+    "angelssmeltinggraphics = 1.0.0",
+    "angelspetrochemgraphics = 1.0.0",
     "boblogistics >= 2.0.2",
     "? RecipeBook >= 4.0.2",
     "? underground-pipe-pack >= 1.1.2",


### PR DESCRIPTION
Closes #52

Due to the recent release of Angel's mods for 2.0, 2.0 graphics mods were released for Angel's mods, which have a different layout for certain files. This causes the 2.0 graphics mods to be incompatible. 

As a quick fix, I have fixed the versions for the graphics mods to 1.0.0, which is the newest version of the graphics mods that is compatible with Nullius.

Future work could include updating this branch to use the new file names of images, allowing Nullius to use the 2.0.0 or newer versions of graphics mods.